### PR TITLE
fix(twilio): reject malformed webhook signatures

### DIFF
--- a/src/lib/providers/__tests__/twilio.test.ts
+++ b/src/lib/providers/__tests__/twilio.test.ts
@@ -146,5 +146,18 @@ describe("TwilioProvider", () => {
       const result = provider.validateWebhook("Body=test", headers, "https://example.com");
       expect(result).toBe(false);
     });
+
+    it("returns false for a malformed signature length", () => {
+      process.env.TWILIO_AUTH_TOKEN = "auth_token_123";
+      const headers = new Headers({ "x-twilio-signature": "invalid" });
+
+      const result = provider.validateWebhook(
+        "Body=test",
+        headers,
+        "https://example.com"
+      );
+
+      expect(result).toBe(false);
+    });
   });
 });

--- a/src/lib/providers/twilio.ts
+++ b/src/lib/providers/twilio.ts
@@ -91,9 +91,11 @@ export class TwilioProvider implements SMSProvider {
     });
 
     const expected = getSignature(authToken, url, params);
-    return crypto.timingSafeEqual(
-      Buffer.from(signature),
-      Buffer.from(expected)
+    const signatureBuffer = Buffer.from(signature);
+    const expectedBuffer = Buffer.from(expected);
+    return (
+      signatureBuffer.length === expectedBuffer.length &&
+      crypto.timingSafeEqual(signatureBuffer, expectedBuffer)
     );
   }
 }


### PR DESCRIPTION
## Summary

- reject malformed Twilio webhook signatures without throwing
- preserve constant-time comparison for signatures with valid lengths
- add regression coverage for truncated signature headers

## Bug

Node's crypto.timingSafeEqual throws when the two buffers have different lengths. A malformed X-Twilio-Signature therefore escaped validation and turned an invalid webhook into a 500 response instead of returning false so the route can reject it with 403.

## Tests

- corepack pnpm test (24 files, 111 tests)
- corepack pnpm typecheck
- corepack pnpm lint